### PR TITLE
Fixed Helix currency

### DIFF
--- a/laux/ccr/tools/shared/currency.laux
+++ b/laux/ccr/tools/shared/currency.laux
@@ -165,16 +165,16 @@ obj:Register()
 
 local obj = CCR.NewCurrency("helix")
 	obj.add = (p, amt) =>
-		p:GiveMoney(amt, false)
+		p:GetCharacter():GiveMoney(amt, false)
 	end
 	obj.get = (p) =>
-		return p:getDarkRPVar("money")
+		return p:GetCharacter():GetMoney()
 	end
 	obj.canAfford = (p, amt) =>
-		return p:HasMoney(amt)
+		return p:GetCharacter():HasMoney(amt)
 	end
 	obj.format = (amt) =>
-		return string.Comma(ix.currency.symbol .. amt)
+		return ix.currency.Get(amt)
 	end
 obj:Register()
 


### PR DESCRIPTION
Meta functions used were for the player, but Helix gets the money from the character. Also fixed formatting to utilize the helix formatting function.